### PR TITLE
Suggestion for a small change: source modules are initialized to new Const objects rather than null pointers. 

### DIFF
--- a/src/main/java/com/flowpowered/noise/module/Module.java
+++ b/src/main/java/com/flowpowered/noise/module/Module.java
@@ -35,8 +35,8 @@ public abstract class Module {
     public Module(int sourceModuleCount) {
 
         // Create an array of pointers to all source modules required by this
-        // noise module.  Set these pointers to Const modules.
-    	sourceModule = new Module[sourceModuleCount];     
+        // noise module. Set these pointers to Const modules.
+        sourceModule = new Module[sourceModuleCount];
         for (int i = 0; i < sourceModuleCount; i++) {
             sourceModule[i] = new Const();
         }
@@ -59,7 +59,9 @@ public abstract class Module {
         this.sourceModule[index] = sourceModule;
     }
 
-    public abstract int getSourceModuleCount();
+    public int getSourceModuleCount() {
+        return sourceModule.length;
+    }
 
     public abstract double getValue(double x, double y, double z);
 }

--- a/src/main/java/com/flowpowered/noise/module/Module.java
+++ b/src/main/java/com/flowpowered/noise/module/Module.java
@@ -27,22 +27,18 @@
 package com.flowpowered.noise.module;
 
 import com.flowpowered.noise.exception.NoModuleException;
+import com.flowpowered.noise.module.source.Const;
 
 public abstract class Module {
     protected Module[] sourceModule;
 
     public Module(int sourceModuleCount) {
-        sourceModule = null;
 
         // Create an array of pointers to all source modules required by this
-        // noise module.  Set these pointers to NULL.
-        if (sourceModuleCount > 0) {
-            sourceModule = new Module[sourceModuleCount];
-            for (int i = 0; i < sourceModuleCount; i++) {
-                sourceModule[i] = null;
-            }
-        } else {
-            sourceModule = null;
+        // noise module.  Set these pointers to Const modules.
+    	sourceModule = new Module[sourceModuleCount];     
+        for (int i = 0; i < sourceModuleCount; i++) {
+            sourceModule[i] = new Const();
         }
     }
 


### PR DESCRIPTION
This way, null pointer errors don't occur, even when all of a module's
source modules haven't explicitly been set.