### PR TITLE
Fix AIOOBE in Curve.java, line 119

### DIFF
--- a/src/main/java/com/flowpowered/noise/module/modifier/Curve.java
+++ b/src/main/java/com/flowpowered/noise/module/modifier/Curve.java
@@ -116,7 +116,7 @@ public class Curve extends Module {
         // smallest input value of the control point array), get the corresponding
         // output value of the nearest control point and exit now.
         if (index1 == index2) {
-            return controlPoints.get(lastIndex).outputValue;
+            return controlPoints.get(index1).outputValue;
         }
 
         // Compute the alpha value used for cubic interpolation.

--- a/src/main/java/com/flowpowered/noise/module/modifier/Curve.java
+++ b/src/main/java/com/flowpowered/noise/module/modifier/Curve.java
@@ -116,7 +116,7 @@ public class Curve extends Module {
         // smallest input value of the control point array), get the corresponding
         // output value of the nearest control point and exit now.
         if (index1 == index2) {
-            return controlPoints.get(indexPos).outputValue;
+            return controlPoints.get(lastIndex).outputValue;
         }
 
         // Compute the alpha value used for cubic interpolation.


### PR DESCRIPTION
When the `for`-loop in line 99-104 terminates without going into a `break`, `indexPos` will have a value of `4` and generate an AIOOBE in line 119 if furthermore `index1 == index2` holds (which can happen, I recreated the complex planet example and was faced with this). Using `lastIndex` fixes this problem.