### PR TITLE
Optimize perlin noise generator.

### DIFF
--- a/src/main/java/com/flowpowered/noise/Noise.java
+++ b/src/main/java/com/flowpowered/noise/Noise.java
@@ -27,7 +27,6 @@
 package com.flowpowered.noise;
 
 public final class Noise {
-    public static final double GRADIENT_MAX = 1.728003;
     private static final int X_NOISE_GEN = 1619;
     private static final int Y_NOISE_GEN = 31337;
     private static final int Z_NOISE_GEN = 6971;
@@ -153,7 +152,7 @@ public final class Noise {
         // Now compute the dot product of the gradient vector with the distance
         // vector.  The resulting value is gradient noise.  Apply a scaling and
         // offset value so that this noise value ranges from 0 to 1.
-        return ((xvGradient * xvPoint) + (yvGradient * yvPoint) + (zvGradient * zvPoint)) / (GRADIENT_MAX * 2) + 0.5;
+        return ((xvGradient * xvPoint) + (yvGradient * yvPoint) + (zvGradient * zvPoint)) + 0.5;
     }
 
     /**

--- a/src/main/java/com/flowpowered/noise/Utils.java
+++ b/src/main/java/com/flowpowered/noise/Utils.java
@@ -218,4 +218,11 @@ public final class Utils {
             -0.786182, -0.583814, 0.202678, 0.0, -0.565191, 0.821858, -0.0714658, 0.0, 0.437895, 0.152598, -0.885981, 0.0, -0.92394, 0.353436, -0.14635, 0.0,
             0.212189, -0.815162, -0.538969, 0.0, -0.859262, 0.143405, -0.491024, 0.0, 0.991353, 0.112814, 0.0670273, 0.0, 0.0337884, -0.979891, -0.196654, 0.0
     };
+
+    static {
+        // pre-scale the vectors to avoid unnecessary division/multiplication when generating noise
+        for (int i = 0; i < RANDOM_VECTORS.length; i++) {
+            RANDOM_VECTORS[i] /= 2 * Math.sqrt(3.0);
+        }
+    }
 }

--- a/src/test/java/com/flowpowered/noise/NoiseTest.java
+++ b/src/test/java/com/flowpowered/noise/NoiseTest.java
@@ -41,9 +41,7 @@ public class NoiseTest {
                 max = gradient;
             }
         }
-        if (max > Noise.GRADIENT_MAX) {
-            Assert.fail("Gradient max it not the max, " + max + " is");
-        }
+        Assert.assertEquals(max, 0.5, 0.01);
         /*
         final int width = 2048, height = 2048;
         final double xPeriod = 128, yPeriod = 128;


### PR DESCRIPTION
This should make gradientCoherentNoise3D almost 2 times faster.

The noise output stays exactly the same (well, maybe there are some tiny differences due to rounding).